### PR TITLE
feauture/2 공통 ApiResponse 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ###
 application.properties
 application-secret.properties
+.DS_Store

--- a/src/main/java/org/millie/www/MillieServer/common/dto/ApiResponse.java
+++ b/src/main/java/org/millie/www/MillieServer/common/dto/ApiResponse.java
@@ -14,20 +14,20 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T>{
 
-    private final HttpStatus status;
-    private final String message;
+    private final int code;
+    private final String msg;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
 
     public static <T> ApiResponse<T> success(SuccessMessage success) {
-        return new ApiResponse(success.getStatus(), success.getMessage());
+        return new ApiResponse(success.getStatus().value(), success.getMessage());
     }
 
     public static <T> ApiResponse<T> success(SuccessMessage success, T data) {
-        return new ApiResponse(success.getStatus(), success.getMessage(), data);
+        return new ApiResponse(success.getStatus().value(), success.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> fail(FailMessage fail) {
-        return new ApiResponse(fail.getStatus(), fail.getMessage());
+        return new ApiResponse(fail.getStatus().value(), fail.getMessage());
     }
 }

--- a/src/main/java/org/millie/www/MillieServer/common/dto/ApiResponse.java
+++ b/src/main/java/org/millie/www/MillieServer/common/dto/ApiResponse.java
@@ -1,0 +1,33 @@
+package org.millie.www.MillieServer.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.millie.www.MillieServer.common.httpmessage.FailMessage;
+import org.millie.www.MillieServer.common.httpmessage.SuccessMessage;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T>{
+
+    private final HttpStatus status;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    public static <T> ApiResponse<T> success(SuccessMessage success) {
+        return new ApiResponse(success.getStatus(), success.getMessage());
+    }
+
+    public static <T> ApiResponse<T> success(SuccessMessage success, T data) {
+        return new ApiResponse(success.getStatus(), success.getMessage(), data);
+    }
+
+    public static <T> ApiResponse<T> fail(FailMessage fail) {
+        return new ApiResponse(fail.getStatus(), fail.getMessage());
+    }
+}

--- a/src/main/java/org/millie/www/MillieServer/common/httpmessage/FailMessage.java
+++ b/src/main/java/org/millie/www/MillieServer/common/httpmessage/FailMessage.java
@@ -1,0 +1,19 @@
+package org.millie.www.MillieServer.common.httpmessage;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum FailMessage {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "000000"),
+    SAME_BOOK_UPDATE_EXCEPTION(HttpStatus.BAD_REQUEST, "000002"),
+    MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.UNAUTHORIZED, "000003");
+
+
+    private HttpStatus status;
+    private String message;
+}

--- a/src/main/java/org/millie/www/MillieServer/common/httpmessage/SuccessMessage.java
+++ b/src/main/java/org/millie/www/MillieServer/common/httpmessage/SuccessMessage.java
@@ -1,0 +1,19 @@
+package org.millie.www.MillieServer.common.httpmessage;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessMessage {
+
+    BEST_BOOK_LIST_SEARCH_SUCCESS(HttpStatus.OK, "000001"),
+    BOOK_SEARCH_SUCCESS(HttpStatus.OK, "000001"),
+    USER_ADD_BOOK_SUCCESS(HttpStatus.CREATED, "000001"),
+    USER_BOOK_LIST_SEARCH_SUCCESS(HttpStatus.OK, "000001");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
##  Related Issue
- close #3 
<br/>

- ApiResponse 생성완료
- FailMessage 생성완료
- SuccessMessage 생성완료

## To Reviewers
- HttpStatus와 message를 갖는 enum SuccessMessage와 FailMessage를 만들어서 ApiResponse에 사용할 수 있도록 하였습니다.
- ApiResponse의 field private T data에는 @JsonInclud(JsonInclude.Include.NON_NULL)을 추가해 response에 data가 없을 때 json에 포함 되지 않도록 하였습니다. 


<br/>